### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ make toolchain-llvm
 ```
 
 Ara also requires an updated Spike ISA simulator, with support for the vector extension.
+There are linking issues with the standard libraries when using newer CC/CXX versions to compile Spike. Therefore, here we resort to older versions of the compilers. If there are problems with dynamic linking, use:
+`make riscv-isa-sim LDFLAGS="-static-libstdc++"`. Spike was compiled successfully using gcc and g++ version 7.2.0.
 
 To build Spike, run the following command in the project's root directory.
 


### PR DESCRIPTION
Added a piece of information that is crucial to the build of SPIKE and should be mentioned in the main README.md instead of the Makefile.

## Changelog
README.md

### Added
- crucial information regarding SPIKE build that should be clearly visible before anyone attempts to build it